### PR TITLE
Add Mastodon link

### DIFF
--- a/index.md
+++ b/index.md
@@ -23,6 +23,8 @@ The group has been using [Quiet][] to keep in touch (#boston in the Quiet-Team c
 
 [Quiet]: https://github.com/TryQuiet/quiet
 
+Follow us on <a rel="me" href="https://floss.social/@bostonopen">Mastodon</a>!
+
 We have a [GitHub org][], [this website][] (pull requests welcome!), a couple logos, and a place for [discussion][]. If you have attended a meetup, you're very welcome to [add yourself][] to our [list][].
 
 [GitHub org]: https://github.com/bostonopen


### PR DESCRIPTION
The rel="me" allows for the "verified" checkmark on Mastodon.

This breaks the nice markdown formatting though. Not sure how much you care about that. If you want, I can try to find a more Markdown-idiomatic way of doing rel="me" if you don't know one off hand.

The Mastodon account is set up for now, so there's at least something to see when you click on this new link. I don't want to add the link back from the Mastodon account to bostonopen.dev until this link is live on bostonopen.dev, so I can confirm right away that the "verified" checkmark works. (Otherwise I don't know how long it'll take for the Mastodon server to check again for the rel="me" tag)

https://floss.social/@bostonopen