### PR TITLE
switch map from default OSM tiles to Carto Voyager

### DIFF
--- a/map.js
+++ b/map.js
@@ -1,7 +1,9 @@
 var map = L.map('map').setView([42.359068001401006, -71.09147396226346], 13);
 
-L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+    subdomains: 'abcd',
+    maxZoom: 20
 }).addTo(map);
 
 fetch('places.json')


### PR DESCRIPTION
## Before: default OpenStreetMap tiles

These tiles look busy to me.

<img width="1028" height="610" alt="Screenshot 2026-07-03 at 10 31 33 AM" src="https://github.com/user-attachments/assets/7bc84c92-11e0-4ff0-bbc9-7623461ba8bf" />

## After: Carto Voyager tiles

Much cleaner.

<img width="1028" height="610" alt="Screenshot 2026-07-03 at 10 32 27 AM" src="https://github.com/user-attachments/assets/f7ba6be5-0aea-4628-9c93-85dfe85d4208" />
